### PR TITLE
Ajuste de tarifa para VAN con multiplicador 1.5 y cobertura de test

### DIFF
--- a/backend/src/main/java/com/quicklift/backend/service/FareService.java
+++ b/backend/src/main/java/com/quicklift/backend/service/FareService.java
@@ -1,6 +1,7 @@
 package com.quicklift.backend.service;
 
 import com.quicklift.backend.dto.TripRequest;
+import com.quicklift.backend.model.VehicleType;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
@@ -13,6 +14,7 @@ public class FareService {
     
     // Per-kilometer rate in rupees
     private static final BigDecimal RATE_PER_KM = new BigDecimal("11.00");
+    private static final BigDecimal VAN_MULTIPLIER = new BigDecimal("1.50");
 
     public double calculateDistance(double lat1, double lon1, double lat2, double lon2) {
         double latDistance = Math.toRadians(lat2 - lat1);
@@ -41,7 +43,11 @@ public class FareService {
         );
 
         BigDecimal tolls = request.getTolls() != null ? request.getTolls() : BigDecimal.ZERO;
-        return calculateFare(distance, tolls);
+        BigDecimal fare = calculateFare(distance, tolls);
+        if (request.getVehicleType() == VehicleType.VAN) {
+            return fare.multiply(VAN_MULTIPLIER).setScale(2, RoundingMode.HALF_UP);
+        }
+        return fare;
     }
 
     public BigDecimal calculateFare(double distance, BigDecimal tolls) {

--- a/backend/src/test/java/com/quicklift/backend/service/FareServiceTest.java
+++ b/backend/src/test/java/com/quicklift/backend/service/FareServiceTest.java
@@ -1,6 +1,7 @@
 package com.quicklift.backend.service;
 
 import com.quicklift.backend.dto.TripRequest;
+import com.quicklift.backend.model.VehicleType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -65,5 +66,20 @@ class FareServiceTest {
                 () -> fareService.calculateFare(request));
 
         assertEquals("Pickup/destination coordinates are required to estimate fare.", exception.getMessage());
+    }
+
+    @Test
+    void calculateFare_tripRequestWithVan_appliesOnePointFiveMultiplier() {
+        TripRequest request = new TripRequest();
+        request.setPickupLatitude(new BigDecimal("40.4168"));
+        request.setPickupLongitude(new BigDecimal("-3.7038"));
+        request.setDestinationLatitude(new BigDecimal("40.4170"));
+        request.setDestinationLongitude(new BigDecimal("-3.7000"));
+        request.setTolls(BigDecimal.ZERO);
+        request.setVehicleType(VehicleType.VAN);
+
+        BigDecimal fare = fareService.calculateFare(request);
+
+        assertEquals(new BigDecimal("5.33"), fare);
     }
 }


### PR DESCRIPTION
TITULO
Ajuste de tarifa para VAN con multiplicador 1.5 y cobertura de test

Descripcion
Se actualiza el calculo de tarifa para aplicar una regla de negocio especifica al tipo de vehiculo VAN, multiplicando la tarifa final por 1.5. El cambio impacta unicamente el servicio de calculo de precios y su suite de pruebas unitarias.

Cambios principales
- Se anadio un multiplicador `1.50` para viajes con `VehicleType.VAN`.
- Se modifico el flujo de `calculateFare(TripRequest)` para aplicar el factor solo cuando el vehiculo es VAN.
- Se anadio una prueba unitaria para validar el calculo final con VAN.

Detalles tecnicos
- En `FareService`, se importa `VehicleType` y se define la constante `VAN_MULTIPLIER = 1.50`.
- Tras calcular la tarifa base (distancia * tarifa por km + peajes), se aplica `fare * 1.50` con redondeo `HALF_UP` a 2 decimales cuando el tipo es VAN.
- En `FareServiceTest`, se incorpora el caso `calculateFare_tripRequestWithVan_appliesOnePointFiveMultiplier` con un resultado esperado de `5.33`.

Orden de revision
1. `backend/src/main/java/com/quicklift/backend/service/FareService.java`
2. `backend/src/test/java/com/quicklift/backend/service/FareServiceTest.java`

Notas para revisores
- La regla nueva aplica sobre la tarifa final ya calculada (incluyendo peajes), no solo sobre el componente de distancia.
- No se modifican endpoints ni contratos de API; el cambio es interno al dominio de calculo de tarifa.
- No existe rama local `develop_v3`; esta descripcion se construyo con diff contra `develop`.

Tests
- Ejecutado: `./mvnw -Dtest=FareServiceTest test`
- Resultado: OK (`Tests run: 6, Failures: 0, Errors: 0, Skipped: 0`)
