### PR TITLE
Implementar multiplicadores de tarifa por tipo de vehiculo

### DIFF
--- a/backend/src/main/java/com/quicklift/backend/model/VehicleType.java
+++ b/backend/src/main/java/com/quicklift/backend/model/VehicleType.java
@@ -1,9 +1,21 @@
 package com.quicklift.backend.model;
 
+import java.math.BigDecimal;
+
 public enum VehicleType {
-    SEDAN,
-    SUV,
-    LUXURY,
-    MOTORCYCLE,
-    VAN
-} 
+    SEDAN(new BigDecimal("1.00")),
+    SUV(new BigDecimal("1.25")),
+    LUXURY(new BigDecimal("1.60")),
+    MOTORCYCLE(new BigDecimal("0.70")),
+    VAN(new BigDecimal("1.40"));
+
+    private final BigDecimal multiplier;
+
+    VehicleType(BigDecimal multiplier) {
+        this.multiplier = multiplier;
+    }
+
+    public BigDecimal getMultiplier() {
+        return multiplier;
+    }
+}

--- a/backend/src/main/java/com/quicklift/backend/service/FareService.java
+++ b/backend/src/main/java/com/quicklift/backend/service/FareService.java
@@ -1,13 +1,10 @@
 package com.quicklift.backend.service;
 
 import com.quicklift.backend.dto.TripRequest;
-import com.quicklift.backend.model.VehicleType;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.util.EnumMap;
-import java.util.Map;
 
 @Service
 public class FareService {
@@ -17,15 +14,6 @@ public class FareService {
     // Per-kilometer rate in rupees
     private static final BigDecimal RATE_PER_KM = new BigDecimal("11.00");
     private static final BigDecimal DEFAULT_MULTIPLIER = BigDecimal.ONE;
-    private static final Map<VehicleType, BigDecimal> VEHICLE_MULTIPLIERS = new EnumMap<>(VehicleType.class);
-
-    static {
-        VEHICLE_MULTIPLIERS.put(VehicleType.SEDAN, new BigDecimal("1.00"));
-        VEHICLE_MULTIPLIERS.put(VehicleType.SUV, new BigDecimal("1.25"));
-        VEHICLE_MULTIPLIERS.put(VehicleType.LUXURY, new BigDecimal("1.60"));
-        VEHICLE_MULTIPLIERS.put(VehicleType.MOTORCYCLE, new BigDecimal("0.70"));
-        VEHICLE_MULTIPLIERS.put(VehicleType.VAN, new BigDecimal("1.40"));
-    }
 
     public double calculateDistance(double lat1, double lon1, double lat2, double lon2) {
         double latDistance = Math.toRadians(lat2 - lat1);
@@ -57,7 +45,7 @@ public class FareService {
         BigDecimal baseFare = calculateFare(distance, tolls);
         BigDecimal multiplier = request.getVehicleType() == null
                 ? DEFAULT_MULTIPLIER
-                : VEHICLE_MULTIPLIERS.getOrDefault(request.getVehicleType(), DEFAULT_MULTIPLIER);
+                : request.getVehicleType().getMultiplier();
 
         return baseFare.multiply(multiplier).setScale(2, RoundingMode.HALF_UP);
     }

--- a/backend/src/main/java/com/quicklift/backend/service/FareService.java
+++ b/backend/src/main/java/com/quicklift/backend/service/FareService.java
@@ -6,6 +6,8 @@ import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.EnumMap;
+import java.util.Map;
 
 @Service
 public class FareService {
@@ -14,7 +16,16 @@ public class FareService {
     
     // Per-kilometer rate in rupees
     private static final BigDecimal RATE_PER_KM = new BigDecimal("11.00");
-    private static final BigDecimal VAN_MULTIPLIER = new BigDecimal("1.50");
+    private static final BigDecimal DEFAULT_MULTIPLIER = BigDecimal.ONE;
+    private static final Map<VehicleType, BigDecimal> VEHICLE_MULTIPLIERS = new EnumMap<>(VehicleType.class);
+
+    static {
+        VEHICLE_MULTIPLIERS.put(VehicleType.SEDAN, new BigDecimal("1.00"));
+        VEHICLE_MULTIPLIERS.put(VehicleType.SUV, new BigDecimal("1.25"));
+        VEHICLE_MULTIPLIERS.put(VehicleType.LUXURY, new BigDecimal("1.60"));
+        VEHICLE_MULTIPLIERS.put(VehicleType.MOTORCYCLE, new BigDecimal("0.70"));
+        VEHICLE_MULTIPLIERS.put(VehicleType.VAN, new BigDecimal("1.40"));
+    }
 
     public double calculateDistance(double lat1, double lon1, double lat2, double lon2) {
         double latDistance = Math.toRadians(lat2 - lat1);
@@ -43,11 +54,12 @@ public class FareService {
         );
 
         BigDecimal tolls = request.getTolls() != null ? request.getTolls() : BigDecimal.ZERO;
-        BigDecimal fare = calculateFare(distance, tolls);
-        if (request.getVehicleType() == VehicleType.VAN) {
-            return fare.multiply(VAN_MULTIPLIER).setScale(2, RoundingMode.HALF_UP);
-        }
-        return fare;
+        BigDecimal baseFare = calculateFare(distance, tolls);
+        BigDecimal multiplier = request.getVehicleType() == null
+                ? DEFAULT_MULTIPLIER
+                : VEHICLE_MULTIPLIERS.getOrDefault(request.getVehicleType(), DEFAULT_MULTIPLIER);
+
+        return baseFare.multiply(multiplier).setScale(2, RoundingMode.HALF_UP);
     }
 
     public BigDecimal calculateFare(double distance, BigDecimal tolls) {

--- a/backend/src/test/java/com/quicklift/backend/service/FareServiceTest.java
+++ b/backend/src/test/java/com/quicklift/backend/service/FareServiceTest.java
@@ -4,8 +4,12 @@ import com.quicklift.backend.dto.TripRequest;
 import com.quicklift.backend.model.VehicleType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.math.BigDecimal;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -68,18 +72,44 @@ class FareServiceTest {
         assertEquals("Pickup/destination coordinates are required to estimate fare.", exception.getMessage());
     }
 
-    @Test
-    void calculateFare_tripRequestWithVan_appliesOnePointFiveMultiplier() {
+    @ParameterizedTest
+    @MethodSource("vehicleMultiplierCases")
+    void calculateFare_tripRequest_appliesVehicleTypeMultiplier(VehicleType vehicleType, BigDecimal expectedFare) {
         TripRequest request = new TripRequest();
         request.setPickupLatitude(new BigDecimal("40.4168"));
         request.setPickupLongitude(new BigDecimal("-3.7038"));
         request.setDestinationLatitude(new BigDecimal("40.4170"));
         request.setDestinationLongitude(new BigDecimal("-3.7000"));
         request.setTolls(BigDecimal.ZERO);
-        request.setVehicleType(VehicleType.VAN);
+        request.setVehicleType(vehicleType);
 
         BigDecimal fare = fareService.calculateFare(request);
 
-        assertEquals(new BigDecimal("5.33"), fare);
+        assertEquals(expectedFare, fare);
+    }
+
+    @Test
+    void calculateFare_tripRequestWithoutVehicleType_usesDefaultMultiplier() {
+        TripRequest request = new TripRequest();
+        request.setPickupLatitude(new BigDecimal("40.4168"));
+        request.setPickupLongitude(new BigDecimal("-3.7038"));
+        request.setDestinationLatitude(new BigDecimal("40.4170"));
+        request.setDestinationLongitude(new BigDecimal("-3.7000"));
+        request.setTolls(BigDecimal.ZERO);
+        request.setVehicleType(null);
+
+        BigDecimal fare = fareService.calculateFare(request);
+
+        assertEquals(new BigDecimal("3.55"), fare);
+    }
+
+    private static Stream<Arguments> vehicleMultiplierCases() {
+        return Stream.of(
+                Arguments.of(VehicleType.SEDAN, new BigDecimal("3.55")),
+                Arguments.of(VehicleType.SUV, new BigDecimal("4.44")),
+                Arguments.of(VehicleType.LUXURY, new BigDecimal("5.68")),
+                Arguments.of(VehicleType.MOTORCYCLE, new BigDecimal("2.49")),
+                Arguments.of(VehicleType.VAN, new BigDecimal("4.97"))
+        );
     }
 }


### PR DESCRIPTION
TITULO
Implementar multiplicadores de tarifa por tipo de vehiculo

Descripcion
Se incorpora el ajuste de tarifa por tipo de vehiculo para que el precio final cambie segun la categoria seleccionada. La logica aplica el multiplicador sobre la tarifa base y mantiene compatibilidad con los componentes existentes del calculo.

Cambios principales
- Se implementa el calculo de tarifa final aplicando multiplicador por `VehicleType`.
- Se define el multiplicador de cada tipo directamente en el enum `VehicleType`.
- Se agrega cobertura de pruebas para todos los tipos de vehiculo y para el caso sin tipo informado.

Detalles tecnicos
- `VehicleType` ahora encapsula un `multiplier` (`SEDAN 1.00`, `SUV 1.25`, `LUXURY 1.60`, `MOTORCYCLE 0.70`, `VAN 1.40`) con `getMultiplier()`.
- `FareService` calcula `baseFare` y luego aplica `finalFare = baseFare * multiplier`; si el tipo es `null`, usa `1.00` por defecto.
- `FareServiceTest` migra a test parametrizado para validar todos los multiplicadores y añade test de fallback para `vehicleType` nulo.

Orden de revision
1. `backend/src/main/java/com/quicklift/backend/model/VehicleType.java`
2. `backend/src/main/java/com/quicklift/backend/service/FareService.java`
3. `backend/src/test/java/com/quicklift/backend/service/FareServiceTest.java`

Notas para revisores
- La rama `develop_v3` no existe en este repositorio local; la descripcion se elaboro comparando contra `develop`.
- El cambio mantiene el contrato actual del servicio y solo modifica la logica de calculo interno de tarifas.

Tests
- Ejecutado: `./mvnw -Dtest=FareServiceTest test`
- Resultado: OK (`Tests run: 11, Failures: 0, Errors: 0, Skipped: 0`)
