### PR TITLE
feat: arquitectura y contrato de geocoding para estimate

### DIFF
--- a/backend/src/main/java/com/quicklift/backend/controller/TripController.java
+++ b/backend/src/main/java/com/quicklift/backend/controller/TripController.java
@@ -2,10 +2,12 @@ package com.quicklift.backend.controller;
 
 import com.quicklift.backend.dto.TripRequest;
 import com.quicklift.backend.dto.FareResponse;
+import com.quicklift.backend.exception.GeocodingException;
 import com.quicklift.backend.model.Trip;
 import com.quicklift.backend.model.TripStatus;
 import com.quicklift.backend.model.User;
 import com.quicklift.backend.service.FareService;
+import com.quicklift.backend.service.TripCoordinateResolverService;
 import com.quicklift.backend.service.TripService;
 import com.quicklift.backend.service.UserService;
 import jakarta.validation.Valid;
@@ -33,17 +35,23 @@ public class TripController {
     @Autowired
     private FareService fareService;
 
+    @Autowired
+    private TripCoordinateResolverService tripCoordinateResolverService;
+
     @PostMapping("/estimate")
     public ResponseEntity<?> estimateFare(@Valid @RequestBody TripRequest tripRequest) {
         try {
+            TripRequest resolvedRequest = tripCoordinateResolverService.resolveCoordinates(tripRequest);
             double distance = fareService.calculateDistance(
-                tripRequest.getPickupLatitude().doubleValue(),
-                tripRequest.getPickupLongitude().doubleValue(),
-                tripRequest.getDestinationLatitude().doubleValue(),
-                tripRequest.getDestinationLongitude().doubleValue()
+                resolvedRequest.getPickupLatitude().doubleValue(),
+                resolvedRequest.getPickupLongitude().doubleValue(),
+                resolvedRequest.getDestinationLatitude().doubleValue(),
+                resolvedRequest.getDestinationLongitude().doubleValue()
             );
-            BigDecimal estimatedFare = fareService.calculateFare(tripRequest);
+            BigDecimal estimatedFare = fareService.calculateFare(resolvedRequest);
             return ResponseEntity.ok(new FareResponse(estimatedFare, distance));
+        } catch (GeocodingException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
         } catch (IllegalArgumentException e) {
             return ResponseEntity.badRequest().body(e.getMessage());
         } catch (Exception e) {

--- a/backend/src/main/java/com/quicklift/backend/exception/GeocodingException.java
+++ b/backend/src/main/java/com/quicklift/backend/exception/GeocodingException.java
@@ -1,0 +1,11 @@
+package com.quicklift.backend.exception;
+
+public class GeocodingException extends RuntimeException {
+    public GeocodingException(String message) {
+        super(message);
+    }
+
+    public GeocodingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/src/main/java/com/quicklift/backend/exception/GeocodingProviderException.java
+++ b/backend/src/main/java/com/quicklift/backend/exception/GeocodingProviderException.java
@@ -1,0 +1,11 @@
+package com.quicklift.backend.exception;
+
+public class GeocodingProviderException extends GeocodingException {
+    public GeocodingProviderException(String message) {
+        super(message);
+    }
+
+    public GeocodingProviderException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/src/main/java/com/quicklift/backend/exception/GeocodingResolutionException.java
+++ b/backend/src/main/java/com/quicklift/backend/exception/GeocodingResolutionException.java
@@ -1,0 +1,11 @@
+package com.quicklift.backend.exception;
+
+public class GeocodingResolutionException extends GeocodingException {
+    public GeocodingResolutionException(String message) {
+        super(message);
+    }
+
+    public GeocodingResolutionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/src/main/java/com/quicklift/backend/service/TripCoordinateResolverService.java
+++ b/backend/src/main/java/com/quicklift/backend/service/TripCoordinateResolverService.java
@@ -1,0 +1,85 @@
+package com.quicklift.backend.service;
+
+import com.quicklift.backend.dto.TripRequest;
+import com.quicklift.backend.exception.GeocodingProviderException;
+import com.quicklift.backend.exception.GeocodingResolutionException;
+import com.quicklift.backend.service.geocoding.GeocodingProvider;
+import com.quicklift.backend.service.geocoding.GeocodingResult;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+
+@Service
+public class TripCoordinateResolverService {
+
+    private final ObjectProvider<GeocodingProvider> geocodingProvider;
+
+    public TripCoordinateResolverService(ObjectProvider<GeocodingProvider> geocodingProvider) {
+        this.geocodingProvider = geocodingProvider;
+    }
+
+    public TripRequest resolveCoordinates(TripRequest request) {
+        if (request == null) {
+            throw new IllegalArgumentException("Trip request is required.");
+        }
+
+        TripRequest resolved = copyRequest(request);
+
+        if (requiresGeocoding(request.getPickupLatitude(), request.getPickupLongitude())) {
+            GeocodingResult pickupResult = resolveAddress(request.getPickupLocation(), "pickup");
+            resolved.setPickupLatitude(pickupResult.getLatitude());
+            resolved.setPickupLongitude(pickupResult.getLongitude());
+        }
+
+        if (requiresGeocoding(request.getDestinationLatitude(), request.getDestinationLongitude())) {
+            GeocodingResult destinationResult = resolveAddress(request.getDestination(), "destination");
+            resolved.setDestinationLatitude(destinationResult.getLatitude());
+            resolved.setDestinationLongitude(destinationResult.getLongitude());
+        }
+
+        return resolved;
+    }
+
+    private boolean requiresGeocoding(BigDecimal latitude, BigDecimal longitude) {
+        return latitude == null || longitude == null;
+    }
+
+    private GeocodingResult resolveAddress(String address, String pointName) {
+        if (address == null || address.isBlank()) {
+            throw new GeocodingResolutionException("Unable to resolve " + pointName + " coordinates.");
+        }
+
+        GeocodingProvider provider = geocodingProvider.getIfAvailable();
+        if (provider == null) {
+            throw new GeocodingProviderException("Geocoding provider is not configured.");
+        }
+
+        GeocodingResult result;
+        try {
+            result = provider.resolve(address);
+        } catch (GeocodingProviderException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new GeocodingProviderException("Geocoding provider failed to resolve address.", ex);
+        }
+
+        if (result == null || result.getLatitude() == null || result.getLongitude() == null) {
+            throw new GeocodingResolutionException("Unable to resolve " + pointName + " coordinates.");
+        }
+
+        return result;
+    }
+
+    private TripRequest copyRequest(TripRequest source) {
+        TripRequest copy = new TripRequest(source.getPickupLocation(), source.getDestination(), source.getVehicleType());
+        copy.setPickupLatitude(source.getPickupLatitude());
+        copy.setPickupLongitude(source.getPickupLongitude());
+        copy.setDestinationLatitude(source.getDestinationLatitude());
+        copy.setDestinationLongitude(source.getDestinationLongitude());
+        copy.setNotes(source.getNotes());
+        copy.setTolls(source.getTolls());
+        copy.setPaymentMethod(source.getPaymentMethod());
+        return copy;
+    }
+}

--- a/backend/src/main/java/com/quicklift/backend/service/geocoding/GeocodingProvider.java
+++ b/backend/src/main/java/com/quicklift/backend/service/geocoding/GeocodingProvider.java
@@ -1,0 +1,5 @@
+package com.quicklift.backend.service.geocoding;
+
+public interface GeocodingProvider {
+    GeocodingResult resolve(String address);
+}

--- a/backend/src/main/java/com/quicklift/backend/service/geocoding/GeocodingResult.java
+++ b/backend/src/main/java/com/quicklift/backend/service/geocoding/GeocodingResult.java
@@ -1,0 +1,21 @@
+package com.quicklift.backend.service.geocoding;
+
+import java.math.BigDecimal;
+
+public class GeocodingResult {
+    private final BigDecimal latitude;
+    private final BigDecimal longitude;
+
+    public GeocodingResult(BigDecimal latitude, BigDecimal longitude) {
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+
+    public BigDecimal getLatitude() {
+        return latitude;
+    }
+
+    public BigDecimal getLongitude() {
+        return longitude;
+    }
+}


### PR DESCRIPTION
TITULO
Arquitectura y contrato de geocoding para estimate con resolver desacoplado

Descripcion
Se incorpora una capa de abstracción para resolver coordenadas en la estimación de tarifa, separando la orquestación de geocoding del cálculo puro de tarifas. El endpoint `/api/trips/estimate` mantiene su contrato y ahora consume un request con coordenadas ya resueltas.

Cambios principales
- Se agrega el contrato `GeocodingProvider` y el value object `GeocodingResult` en `service/geocoding`.
- Se crea `TripCoordinateResolverService` para resolver coordenadas faltantes o parciales de pickup/destination antes del cálculo.
- Se añaden excepciones controladas de geocoding para diferenciar fallo de proveedor y fallo de resolución.
- Se integra el resolver en `TripController` dentro del flujo de `/api/trips/estimate` devolviendo `HTTP 400` con mensaje simple en errores de geocoding.

Detalles tecnicos
- `TripCoordinateResolverService` aplica reglas de resolución por punto: si falta una o ambas coordenadas, geocodifica y reemplaza lat/lon del punto completo.
- El resolver depende de `ObjectProvider<GeocodingProvider>` para desacoplar la orquestación de una implementación concreta de proveedor.
- El servicio de tarifas (`FareService`) se mantiene sin dependencias de proveedores externos.
- Se copia el `TripRequest` original a un request resuelto para evitar mutaciones laterales sobre el objeto de entrada.

Orden de revision
1. `backend/src/main/java/com/quicklift/backend/service/geocoding/GeocodingProvider.java` y `GeocodingResult.java`
2. `backend/src/main/java/com/quicklift/backend/service/TripCoordinateResolverService.java`
3. `backend/src/main/java/com/quicklift/backend/controller/TripController.java`
4. `backend/src/main/java/com/quicklift/backend/exception/GeocodingException.java` y derivadas

Notas para revisores
- No existe `develop_v3` en el repositorio local; la comparación para esta PR se realizó contra `develop`.
- En esta tarea se define arquitectura/contrato y esqueleto de orquestación; la implementación HTTP de proveedor queda para la siguiente spec.
- Si no hay bean de `GeocodingProvider` y se requiere geocoding, se devuelve error controlado de configuración.

Tests
- Ejecutado: `./mvnw -DskipTests compile` (OK).
- Ejecutado: `./mvnw test` (falla por entorno de Mockito/ByteBuddy en Java 25: `Could not initialize inline Byte Buddy mock maker`).
