### PR TITLE
Issue #2: vehicle type multiplier in fare calculation

### DIFF
--- a/backend/src/main/java/com/quicklift/backend/service/FareService.java
+++ b/backend/src/main/java/com/quicklift/backend/service/FareService.java
@@ -1,10 +1,13 @@
 package com.quicklift.backend.service;
 
 import com.quicklift.backend.dto.TripRequest;
+import com.quicklift.backend.model.VehicleType;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.EnumMap;
+import java.util.Map;
 
 @Service
 public class FareService {
@@ -13,6 +16,15 @@ public class FareService {
     
     // Per-kilometer rate in rupees
     private static final BigDecimal RATE_PER_KM = new BigDecimal("11.00");
+    private static final Map<VehicleType, BigDecimal> VEHICLE_MULTIPLIERS = new EnumMap<>(VehicleType.class);
+
+    static {
+        VEHICLE_MULTIPLIERS.put(VehicleType.SEDAN, new BigDecimal("1.0"));
+        VEHICLE_MULTIPLIERS.put(VehicleType.SUV, new BigDecimal("1.25"));
+        VEHICLE_MULTIPLIERS.put(VehicleType.LUXURY, new BigDecimal("1.6"));
+        VEHICLE_MULTIPLIERS.put(VehicleType.MOTORCYCLE, new BigDecimal("0.7"));
+        VEHICLE_MULTIPLIERS.put(VehicleType.VAN, new BigDecimal("1.4"));
+    }
 
     public double calculateDistance(double lat1, double lon1, double lat2, double lon2) {
         double latDistance = Math.toRadians(lat2 - lat1);
@@ -41,11 +53,17 @@ public class FareService {
         );
 
         BigDecimal tolls = request.getTolls() != null ? request.getTolls() : BigDecimal.ZERO;
-        return calculateFare(distance, tolls);
+        return calculateFare(distance, tolls, request.getVehicleType());
     }
 
     public BigDecimal calculateFare(double distance, BigDecimal tolls) {
-        BigDecimal distanceCost = BigDecimal.valueOf(distance).multiply(RATE_PER_KM);
-        return distanceCost.add(tolls).setScale(2, RoundingMode.HALF_UP);
+        return calculateFare(distance, tolls, null);
     }
-} 
+
+    public BigDecimal calculateFare(double distance, BigDecimal tolls, VehicleType vehicleType) {
+        BigDecimal distanceCost = BigDecimal.valueOf(distance).multiply(RATE_PER_KM);
+        BigDecimal baseFare = distanceCost.add(tolls);
+        BigDecimal multiplier = VEHICLE_MULTIPLIERS.getOrDefault(vehicleType, BigDecimal.ONE);
+        return baseFare.multiply(multiplier).setScale(2, RoundingMode.HALF_UP);
+    }
+}

--- a/backend/src/test/java/com/quicklift/backend/service/FareServiceTest.java
+++ b/backend/src/test/java/com/quicklift/backend/service/FareServiceTest.java
@@ -1,0 +1,75 @@
+package com.quicklift.backend.service;
+
+import com.quicklift.backend.dto.TripRequest;
+import com.quicklift.backend.model.VehicleType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.math.BigDecimal;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class FareServiceTest {
+
+    private final FareService fareService = new FareService();
+
+    @ParameterizedTest
+    @MethodSource("vehicleFareCases")
+    void shouldApplyVehicleMultiplierToBaseFare(VehicleType vehicleType, String expectedFare) {
+        BigDecimal fare = fareService.calculateFare(10.0, new BigDecimal("5.00"), vehicleType);
+
+        assertThat(fare).isEqualByComparingTo(new BigDecimal(expectedFare));
+    }
+
+    @Test
+    void shouldUseDefaultMultiplierWhenVehicleTypeIsMissing() {
+        BigDecimal fare = fareService.calculateFare(10.0, new BigDecimal("5.00"), null);
+
+        assertThat(fare).isEqualByComparingTo(new BigDecimal("115.00"));
+    }
+
+    @Test
+    void shouldUseDefaultMultiplierInOverloadWithoutVehicleType() {
+        BigDecimal fare = fareService.calculateFare(10.0, new BigDecimal("5.00"));
+
+        assertThat(fare).isEqualByComparingTo(new BigDecimal("115.00"));
+    }
+
+    @Test
+    void shouldThrowWhenCoordinatesAreMissing() {
+        TripRequest request = new TripRequest();
+
+        assertThatThrownBy(() -> fareService.calculateFare(request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Pickup/destination coordinates are required to estimate fare.");
+    }
+
+    @Test
+    void shouldUseDefaultMultiplierWhenTripRequestDoesNotIncludeVehicleType() {
+        TripRequest request = new TripRequest();
+        request.setPickupLatitude(new BigDecimal("40.4168"));
+        request.setPickupLongitude(new BigDecimal("-3.7038"));
+        request.setDestinationLatitude(new BigDecimal("40.4168"));
+        request.setDestinationLongitude(new BigDecimal("-3.7038"));
+        request.setTolls(new BigDecimal("10.00"));
+        request.setVehicleType(null);
+
+        BigDecimal fare = fareService.calculateFare(request);
+
+        assertThat(fare).isEqualByComparingTo(new BigDecimal("10.00"));
+    }
+
+    private static Stream<Arguments> vehicleFareCases() {
+        return Stream.of(
+                Arguments.of(VehicleType.SEDAN, "115.00"),
+                Arguments.of(VehicleType.SUV, "143.75"),
+                Arguments.of(VehicleType.LUXURY, "184.00"),
+                Arguments.of(VehicleType.MOTORCYCLE, "80.50"),
+                Arguments.of(VehicleType.VAN, "161.00")
+        );
+    }
+}


### PR DESCRIPTION
TITULO
Implementar multiplicador por tipo de vehículo en cálculo de tarifa

Descripcion
Se incorpora el ajuste de tarifa final en función del tipo de vehículo solicitado para que la estimación y la reserva reflejen precios diferenciados por categoría.

Cambios principales
- Se agregó un mapeo de multiplicadores por `VehicleType` en `FareService`.
- Se actualizó el cálculo de tarifa para aplicar el multiplicador al `baseFare` calculado.
- Se añadió comportamiento por defecto con multiplicador `1.0` cuando no se informa tipo de vehículo.

Detalles tecnicos
- `calculateFare(TripRequest)` ahora delega en una nueva sobrecarga `calculateFare(distance, tolls, vehicleType)`.
- Se mantiene la firma existente `calculateFare(distance, tolls)` y se enruta internamente al cálculo con `vehicleType = null` para conservar compatibilidad.
- El multiplicador se resuelve con `EnumMap<VehicleType, BigDecimal>` y `getOrDefault(..., BigDecimal.ONE)`.

Orden de revision
1. `backend/src/main/java/com/quicklift/backend/service/FareService.java`
2. `backend/src/test/java/com/quicklift/backend/service/FareServiceTest.java`

Notas para revisores
- El multiplicador se aplica sobre el `baseFare` actual (distancia + peajes) antes del redondeo final.
- El fallback de tipo de vehículo nulo evita romper flujos donde no venga `vehicleType` en la capa de servicio.

Tests
- `./mvnw test` (OK)

Closes #2
