### PR TITLE
Implementar multiplicadores por tipo de vehículo en cálculo de tarifa

### DIFF
--- a/backend/src/main/java/com/quicklift/backend/service/FareService.java
+++ b/backend/src/main/java/com/quicklift/backend/service/FareService.java
@@ -1,18 +1,27 @@
 package com.quicklift.backend.service;
 
 import com.quicklift.backend.dto.TripRequest;
+import com.quicklift.backend.model.VehicleType;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.Map;
 
 @Service
 public class FareService {
 
     private static final double EARTH_RADIUS_KM = 6371;
     
-    // Per-kilometer rate in rupees
     private static final BigDecimal RATE_PER_KM = new BigDecimal("11.00");
+    private static final BigDecimal DEFAULT_MULTIPLIER = BigDecimal.ONE;
+    private static final Map<VehicleType, BigDecimal> VEHICLE_MULTIPLIERS = Map.of(
+            VehicleType.SEDAN, new BigDecimal("1.0"),
+            VehicleType.SUV, new BigDecimal("1.25"),
+            VehicleType.LUXURY, new BigDecimal("1.6"),
+            VehicleType.MOTORCYCLE, new BigDecimal("0.7"),
+            VehicleType.VAN, new BigDecimal("1.4")
+    );
 
     public double calculateDistance(double lat1, double lon1, double lat2, double lon2) {
         double latDistance = Math.toRadians(lat2 - lat1);
@@ -27,9 +36,6 @@ public class FareService {
     public BigDecimal calculateFare(TripRequest request) {
         if (request.getPickupLatitude() == null || request.getPickupLongitude() == null ||
             request.getDestinationLatitude() == null || request.getDestinationLongitude() == null) {
-            // Cannot calculate fare without coordinates, return a default or throw exception
-            // For now, let's return a default value or handle as an error.
-            // Returning zero or a default could be misleading. Let's throw an exception.
             throw new IllegalArgumentException("Pickup/destination coordinates are required to estimate fare.");
         }
 
@@ -41,7 +47,12 @@ public class FareService {
         );
 
         BigDecimal tolls = request.getTolls() != null ? request.getTolls() : BigDecimal.ZERO;
-        return calculateFare(distance, tolls);
+        BigDecimal baseFare = calculateFare(distance, tolls);
+        VehicleType vehicleType = request.getVehicleType();
+        BigDecimal multiplier = vehicleType == null
+                ? DEFAULT_MULTIPLIER
+                : VEHICLE_MULTIPLIERS.getOrDefault(vehicleType, DEFAULT_MULTIPLIER);
+        return baseFare.multiply(multiplier).setScale(2, RoundingMode.HALF_UP);
     }
 
     public BigDecimal calculateFare(double distance, BigDecimal tolls) {

--- a/backend/src/test/java/com/quicklift/backend/service/FareServiceTest.java
+++ b/backend/src/test/java/com/quicklift/backend/service/FareServiceTest.java
@@ -1,0 +1,118 @@
+package com.quicklift.backend.service;
+
+import com.quicklift.backend.dto.TripRequest;
+import com.quicklift.backend.model.VehicleType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.math.BigDecimal;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class FareServiceTest {
+
+    private FareService fareService;
+
+    @BeforeEach
+    void setUp() {
+        fareService = new FareService();
+    }
+
+    @Test
+    void calculateDistance_sameCoordinates_returnsZero() {
+        double distance = fareService.calculateDistance(40.4168, -3.7038, 40.4168, -3.7038);
+
+        assertEquals(0.0, distance, 1e-9);
+    }
+
+    @Test
+    void calculateDistance_betweenMadridAndBarcelona_returnsExpectedRange() {
+        double distance = fareService.calculateDistance(40.4168, -3.7038, 41.3874, 2.1686);
+
+        assertEquals(505, distance, 10);
+    }
+
+    @Test
+    void calculateFare_withDistanceAndTolls_returnsRoundedAmount() {
+        BigDecimal fare = fareService.calculateFare(10.0, new BigDecimal("5.55"));
+
+        assertEquals(new BigDecimal("115.55"), fare);
+    }
+
+    @Test
+    void calculateFare_withTripRequestAndNoTolls_usesZeroTolls() {
+        TripRequest request = new TripRequest();
+        request.setPickupLatitude(new BigDecimal("40.4168"));
+        request.setPickupLongitude(new BigDecimal("-3.7038"));
+        request.setDestinationLatitude(new BigDecimal("40.4180"));
+        request.setDestinationLongitude(new BigDecimal("-3.7000"));
+
+        BigDecimal fare = fareService.calculateFare(request);
+
+        assertEquals(new BigDecimal("3.83"), fare);
+    }
+
+    @Test
+    void calculateFare_withTripRequestAndTolls_includesTolls() {
+        TripRequest request = new TripRequest();
+        request.setPickupLatitude(new BigDecimal("40.4168"));
+        request.setPickupLongitude(new BigDecimal("-3.7038"));
+        request.setDestinationLatitude(new BigDecimal("40.4180"));
+        request.setDestinationLongitude(new BigDecimal("-3.7000"));
+        request.setTolls(new BigDecimal("2.00"));
+
+        BigDecimal fare = fareService.calculateFare(request);
+
+        assertEquals(new BigDecimal("5.83"), fare);
+    }
+
+    @ParameterizedTest
+    @MethodSource("vehicleMultiplierCases")
+    void calculateFare_withTripRequestAndVehicleType_appliesExpectedMultiplier(VehicleType vehicleType, BigDecimal expectedFare) {
+        TripRequest request = buildTripRequestWithTolls();
+        request.setVehicleType(vehicleType);
+
+        BigDecimal fare = fareService.calculateFare(request);
+
+        assertEquals(expectedFare, fare);
+    }
+
+    @Test
+    void calculateFare_withMissingCoordinates_throwsIllegalArgumentException() {
+        TripRequest request = new TripRequest();
+        request.setPickupLatitude(new BigDecimal("40.4168"));
+        request.setPickupLongitude(new BigDecimal("-3.7038"));
+        request.setDestinationLatitude(new BigDecimal("40.4180"));
+        request.setDestinationLongitude(null);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> fareService.calculateFare(request));
+
+        assertEquals("Pickup/destination coordinates are required to estimate fare.", exception.getMessage());
+    }
+
+    private static Stream<Arguments> vehicleMultiplierCases() {
+        return Stream.of(
+                Arguments.of(VehicleType.SEDAN, new BigDecimal("5.83")),
+                Arguments.of(VehicleType.SUV, new BigDecimal("7.29")),
+                Arguments.of(VehicleType.LUXURY, new BigDecimal("9.33")),
+                Arguments.of(VehicleType.MOTORCYCLE, new BigDecimal("4.08")),
+                Arguments.of(VehicleType.VAN, new BigDecimal("8.16")),
+                Arguments.of(null, new BigDecimal("5.83"))
+        );
+    }
+
+    private TripRequest buildTripRequestWithTolls() {
+        TripRequest request = new TripRequest();
+        request.setPickupLatitude(new BigDecimal("40.4168"));
+        request.setPickupLongitude(new BigDecimal("-3.7038"));
+        request.setDestinationLatitude(new BigDecimal("40.4180"));
+        request.setDestinationLongitude(new BigDecimal("-3.7000"));
+        request.setTolls(new BigDecimal("2.00"));
+        return request;
+    }
+}


### PR DESCRIPTION
TITULO
Implementar multiplicadores por tipo de vehículo en el cálculo de tarifa

Descripcion
Se actualiza el servicio de tarifas para que el precio final cambie según el tipo de vehículo solicitado, aplicando un multiplicador sobre la tarifa base (distancia + peajes). Incluye fallback a multiplicador por defecto cuando no se informa el tipo.

Cambios principales
- Se agregó un mapeo de multiplicadores por VehicleType en FareService.
- Se aplica el multiplicador después de calcular la tarifa base.
- Se creó una suite de tests unitarios de FareService incluyendo cobertura de todos los tipos de vehículo y el caso sin tipo.

Detalles tecnicos
- Nuevo Map<VehicleType, BigDecimal> con valores: SEDAN=1.0, SUV=1.25, LUXURY=1.6, MOTORCYCLE=0.7, VAN=1.4.
- Se añadió DEFAULT_MULTIPLIER = 1.0 para soportar vehicleType nulo.
- El resultado final mantiene redondeo a 2 decimales con RoundingMode.HALF_UP.

Orden de revision
1. backend/src/main/java/com/quicklift/backend/service/FareService.java
2. backend/src/test/java/com/quicklift/backend/service/FareServiceTest.java

Notas para revisores
- Se conserva la lógica existente de tarifa base (distance * RATE_PER_KM + tolls) y solo se extiende la etapa final con el multiplicador.
- El comportamiento por defecto para tipo no informado queda explícito en código y tests.

Tests
- Ejecutado: mvn -q -Dtest=FareServiceTest test
- Ejecutado: mvn -q test

Closes #2
